### PR TITLE
fix: adversarial hardening of execution and runtime boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-and-test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         go: ['1.25']

--- a/docs/adversarial-hardening.md
+++ b/docs/adversarial-hardening.md
@@ -1,0 +1,41 @@
+# Execution and session hardening
+
+This batch tightens the execution, WASM, TCP, and experimental runtime paths.
+
+- `tool.Orchestrator` implements `loop.ToolExecutor` directly. Tool lookup and
+  permission checks use the same resolved instance; toolkit registration rejects
+  case-insensitive name collisions, and schema enumeration is deterministic.
+- `UnifiedAgentRunner` applies the agent permission engine and acting middleware.
+  The loop bridge returns a tool error for confirmation-required or external
+  execution. Use `UnifiedAgent.ReplyStream` for interactive confirmation.
+- Synchronous Bash execution reports a nonzero exit as a tool error, including
+  execution through a configured backend.
+- WASM requests propagate fuel, memory, directory grants, and output limits.
+  The CLI implementation enforces these settings through Wasmtime; Wasmer and
+  wasm3 return `ErrUnsupportedLimits` with the default resource limits. Combined
+  stdout/stderr capture defaults to 1 MiB and reports `OutputTruncated`.
+  Directory grants expose host paths to the module; grant only intended paths.
+- `a2a/grpc` uses newline-delimited JSON over TCP. It is not the gRPC wire
+  protocol. Transport I/O observes context cancellation, and client/server close
+  releases idle connections. Active request and stream IDs share one namespace.
+  Use a fresh ID when retrying a canceled request: late responses cannot be
+  distinguished from a new request using the same ID on this wire protocol.
+- `runtime.SessionEngine` serializes turns and preserves the context manager
+  configured through `loop.WithContextManager`, including restored history.
+  The loop options are resolved once when the engine is constructed. A turn
+  waits for the loop to finish after a budget stop before saving history or
+  allowing the next turn to run. Session state includes conversation messages;
+  file-store saves use atomic replacement.
+
+## Scope and remaining limits
+
+This batch does not establish a complete isolation boundary for arbitrary
+custom tools. Configure a workspace backend for isolated shell/file execution.
+The TCP stream consumer must continue draining its channel or close its client;
+stream-context cancellation alone does not retire an established stream.
+Session-state snapshots copy the message slice but share message objects, and
+session-store saves do not provide an automatic restore/resume constructor.
+
+Validation uses the PR's GitHub Actions build, vet, race tests, and lint jobs,
+alongside adversarial review. This document describes behavior, not a claim that
+every remaining repository-wide audit finding has been resolved.

--- a/pkg/agentscope/a2a/grpc/transport.go
+++ b/pkg/agentscope/a2a/grpc/transport.go
@@ -255,16 +255,17 @@ func (s *Server) Close() error {
 
 // Client connects to a remote agent server.
 type Client struct {
-	addr      string
-	conn      net.Conn
-	t         *connTransport
-	mu        sync.Mutex
-	pending   map[string]chan *Message
-	streams   map[string]chan *Message
-	closed    chan struct{}
-	closeOnce sync.Once
-	closeErr  error
-	readWg    sync.WaitGroup
+	addr       string
+	conn       net.Conn
+	t          *connTransport
+	mu         sync.Mutex
+	pending    map[string]chan *Message
+	streams    map[string]chan *Message
+	closed     chan struct{}
+	readClosed bool
+	closeOnce  sync.Once
+	closeErr   error
+	readWg     sync.WaitGroup
 }
 
 // NewClient connects to the remote server at addr.
@@ -298,6 +299,11 @@ func (c *Client) readLoop() {
 		c.mu.Lock()
 		streamCh, isStream := c.streams[msg.ID]
 		pendingCh, isPending := c.pending[msg.ID]
+		// Claim this response while holding the registry lock. A canceled
+		// request may be replaced as soon as the lock is released.
+		if isPending && !isStream {
+			delete(c.pending, msg.ID)
+		}
 		c.mu.Unlock()
 
 		// Never hold c.mu while sending to a consumer-controlled channel.
@@ -309,16 +315,15 @@ func (c *Client) readLoop() {
 			}
 			if msg.StreamEnd {
 				c.mu.Lock()
-				delete(c.streams, msg.ID)
+				if c.streams[msg.ID] == streamCh {
+					delete(c.streams, msg.ID)
+				}
 				c.mu.Unlock()
 				close(streamCh)
 			}
 		} else if isPending {
 			pendingCh <- msg
 			close(pendingCh)
-			c.mu.Lock()
-			delete(c.pending, msg.ID)
-			c.mu.Unlock()
 		}
 	}
 }
@@ -326,6 +331,7 @@ func (c *Client) readLoop() {
 func (c *Client) closeResponseChannels() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.readClosed = true
 	for id, ch := range c.pending {
 		close(ch)
 		delete(c.pending, id)
@@ -338,10 +344,17 @@ func (c *Client) closeResponseChannels() {
 
 // Send sends a request and waits for a single response (request-response pattern).
 func (c *Client) Send(ctx context.Context, msg *Message) (*Message, error) {
+	if msg == nil {
+		return nil, errors.New("client: nil message")
+	}
 	ch := make(chan *Message, 1)
 
 	c.mu.Lock()
-	if _, exists := c.pending[msg.ID]; exists {
+	if c.readClosed {
+		c.mu.Unlock()
+		return nil, errors.New("client: connection closed")
+	}
+	if c.pending[msg.ID] != nil || c.streams[msg.ID] != nil {
 		c.mu.Unlock()
 		return nil, fmt.Errorf("client: duplicate request ID %q", msg.ID)
 	}
@@ -350,7 +363,9 @@ func (c *Client) Send(ctx context.Context, msg *Message) (*Message, error) {
 
 	if err := c.t.Send(ctx, msg); err != nil {
 		c.mu.Lock()
-		delete(c.pending, msg.ID)
+		if c.pending[msg.ID] == ch {
+			delete(c.pending, msg.ID)
+		}
 		c.mu.Unlock()
 		return nil, fmt.Errorf("client: send: %w", err)
 	}
@@ -358,7 +373,9 @@ func (c *Client) Send(ctx context.Context, msg *Message) (*Message, error) {
 	select {
 	case <-ctx.Done():
 		c.mu.Lock()
-		delete(c.pending, msg.ID)
+		if c.pending[msg.ID] == ch {
+			delete(c.pending, msg.ID)
+		}
 		c.mu.Unlock()
 		return nil, ctx.Err()
 	case resp, ok := <-ch:
@@ -372,20 +389,30 @@ func (c *Client) Send(ctx context.Context, msg *Message) (*Message, error) {
 // Stream sends a message and returns a channel that receives streaming responses.
 // The channel is closed after a message with StreamEnd=true is received.
 func (c *Client) Stream(ctx context.Context, msg *Message) (<-chan *Message, error) {
+	if msg == nil {
+		return nil, errors.New("client: nil message")
+	}
 	ch := make(chan *Message, 64)
 
 	c.mu.Lock()
-	if _, exists := c.streams[msg.ID]; exists {
+	if c.readClosed {
+		c.mu.Unlock()
+		return nil, errors.New("client: connection closed")
+	}
+	if c.streams[msg.ID] != nil || c.pending[msg.ID] != nil {
 		c.mu.Unlock()
 		return nil, fmt.Errorf("client: duplicate stream ID %q", msg.ID)
 	}
 	c.streams[msg.ID] = ch
 	c.mu.Unlock()
 
-	msg.IsStream = true
-	if err := c.t.Send(ctx, msg); err != nil {
+	request := *msg
+	request.IsStream = true
+	if err := c.t.Send(ctx, &request); err != nil {
 		c.mu.Lock()
-		delete(c.streams, msg.ID)
+		if c.streams[msg.ID] == ch {
+			delete(c.streams, msg.ID)
+		}
 		c.mu.Unlock()
 		return nil, fmt.Errorf("client: stream send: %w", err)
 	}

--- a/pkg/agentscope/a2a/grpc/transport.go
+++ b/pkg/agentscope/a2a/grpc/transport.go
@@ -48,14 +48,27 @@ func newConnTransport(conn net.Conn) *connTransport {
 	}
 }
 
-func (t *connTransport) Send(_ context.Context, msg *Message) error {
+func (t *connTransport) Send(ctx context.Context, msg *Message) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return t.encoder.Encode(msg)
+	restore := armContextDeadline(ctx, t.conn.SetWriteDeadline)
+	defer restore()
+	if err := t.encoder.Encode(msg); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return err
+	}
+	return nil
 }
 
-func (t *connTransport) Receive(_ context.Context) (*Message, error) {
+func (t *connTransport) Receive(ctx context.Context) (*Message, error) {
+	restore := armContextDeadline(ctx, t.conn.SetReadDeadline)
+	defer restore()
 	if !t.scanner.Scan() {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		if err := t.scanner.Err(); err != nil {
 			return nil, fmt.Errorf("transport: read: %w", err)
 		}
@@ -66,6 +79,25 @@ func (t *connTransport) Receive(_ context.Context) (*Message, error) {
 		return nil, fmt.Errorf("transport: unmarshal: %w", err)
 	}
 	return &msg, nil
+}
+
+func armContextDeadline(ctx context.Context, setDeadline func(time.Time) error) func() {
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = setDeadline(deadline)
+	} else {
+		_ = setDeadline(time.Time{})
+	}
+	callbackDone := make(chan struct{})
+	stop := context.AfterFunc(ctx, func() {
+		_ = setDeadline(time.Now())
+		close(callbackDone)
+	})
+	return func() {
+		if !stop() {
+			<-callbackDone
+		}
+		_ = setDeadline(time.Time{})
+	}
 }
 
 func (t *connTransport) Close() error {
@@ -141,8 +173,15 @@ func (s *Server) Listen(ctx context.Context) error {
 			}
 		}
 		s.mu.Lock()
+		select {
+		case <-s.done:
+			s.mu.Unlock()
+			_ = conn.Close()
+			return nil
+		default:
+		}
 		s.conns = append(s.conns, conn)
-		s.wg.Add(1) // must be inside the lock to avoid racing with Close's wg.Wait
+		s.wg.Add(1)
 		s.mu.Unlock()
 
 		go s.handleConn(conn)
@@ -152,6 +191,7 @@ func (s *Server) Listen(ctx context.Context) error {
 func (s *Server) handleConn(conn net.Conn) {
 	defer s.wg.Done()
 	defer func() { _ = conn.Close() }()
+	defer s.removeConn(conn)
 
 	t := newConnTransport(conn)
 	for {
@@ -175,6 +215,17 @@ func (s *Server) handleConn(conn net.Conn) {
 	}
 }
 
+func (s *Server) removeConn(conn net.Conn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, tracked := range s.conns {
+		if tracked == conn {
+			s.conns = append(s.conns[:i], s.conns[i+1:]...)
+			return
+		}
+	}
+}
+
 // Close shuts down the server and all active connections.
 // It is safe to call Close concurrently or multiple times.
 func (s *Server) Close() error {
@@ -187,24 +238,17 @@ func (s *Server) Close() error {
 		s.mu.Unlock()
 		s.closeErr = ln.Close()
 
-		// After ln.Close(), Accept will fail and the for-loop exits.
-		// However, a conn may have been accepted just before ln.Close().
-		// Its wg.Add(1) is under s.mu. Acquire+release the lock to
-		// ensure any in-flight wg.Add(1) completes before we Wait.
-		s.mu.Lock() //nolint:gocritic // sync barrier
-		//nolint:staticcheck // intentional lock-unlock to synchronize
-		s.mu.Unlock() //nolint:gocritic // intentional: sync barrier for wg.Add
-
-		// Now safe: no new wg.Add(1) can happen.
-		s.wg.Wait()
-
-		// Close all tracked connections.
+		// Closing active connections unblocks handlers waiting in Receive. Listen
+		// checks s.done while holding this same lock before every wg.Add, so after
+		// this snapshot no new handler can be registered.
 		s.mu.Lock()
-		for _, c := range s.conns {
-			_ = c.Close()
-		}
+		conns := append([]net.Conn(nil), s.conns...)
 		s.conns = nil
 		s.mu.Unlock()
+		for _, c := range conns {
+			_ = c.Close()
+		}
+		s.wg.Wait()
 	})
 	return s.closeErr
 }
@@ -219,6 +263,7 @@ type Client struct {
 	streams   map[string]chan *Message
 	closed    chan struct{}
 	closeOnce sync.Once
+	closeErr  error
 	readWg    sync.WaitGroup
 }
 
@@ -243,44 +288,51 @@ func NewClient(addr string) (*Client, error) {
 
 func (c *Client) readLoop() {
 	defer c.readWg.Done()
+	defer c.closeResponseChannels()
 	for {
 		msg, err := c.t.Receive(context.Background())
 		if err != nil {
-			select {
-			case <-c.closed:
-				return
-			default:
-				// Connection error: close all pending channels
-				c.mu.Lock()
-				for _, ch := range c.pending {
-					close(ch)
-				}
-				c.pending = make(map[string]chan *Message)
-				for _, ch := range c.streams {
-					close(ch)
-				}
-				c.streams = make(map[string]chan *Message)
-				c.mu.Unlock()
-				return
-			}
+			return
 		}
 
 		c.mu.Lock()
-		// Check if it is a streaming response
-		if ch, ok := c.streams[msg.ID]; ok {
-			if msg.StreamEnd {
-				ch <- msg
-				close(ch)
-				delete(c.streams, msg.ID)
-			} else {
-				ch <- msg
-			}
-		} else if ch, ok := c.pending[msg.ID]; ok {
-			ch <- msg
-			close(ch)
-			delete(c.pending, msg.ID)
-		}
+		streamCh, isStream := c.streams[msg.ID]
+		pendingCh, isPending := c.pending[msg.ID]
 		c.mu.Unlock()
+
+		// Never hold c.mu while sending to a consumer-controlled channel.
+		if isStream {
+			select {
+			case streamCh <- msg:
+			case <-c.closed:
+				return
+			}
+			if msg.StreamEnd {
+				c.mu.Lock()
+				delete(c.streams, msg.ID)
+				c.mu.Unlock()
+				close(streamCh)
+			}
+		} else if isPending {
+			pendingCh <- msg
+			close(pendingCh)
+			c.mu.Lock()
+			delete(c.pending, msg.ID)
+			c.mu.Unlock()
+		}
+	}
+}
+
+func (c *Client) closeResponseChannels() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for id, ch := range c.pending {
+		close(ch)
+		delete(c.pending, id)
+	}
+	for id, ch := range c.streams {
+		close(ch)
+		delete(c.streams, id)
 	}
 }
 
@@ -289,6 +341,10 @@ func (c *Client) Send(ctx context.Context, msg *Message) (*Message, error) {
 	ch := make(chan *Message, 1)
 
 	c.mu.Lock()
+	if _, exists := c.pending[msg.ID]; exists {
+		c.mu.Unlock()
+		return nil, fmt.Errorf("client: duplicate request ID %q", msg.ID)
+	}
 	c.pending[msg.ID] = ch
 	c.mu.Unlock()
 
@@ -319,6 +375,10 @@ func (c *Client) Stream(ctx context.Context, msg *Message) (<-chan *Message, err
 	ch := make(chan *Message, 64)
 
 	c.mu.Lock()
+	if _, exists := c.streams[msg.ID]; exists {
+		c.mu.Unlock()
+		return nil, fmt.Errorf("client: duplicate stream ID %q", msg.ID)
+	}
 	c.streams[msg.ID] = ch
 	c.mu.Unlock()
 
@@ -338,8 +398,8 @@ func (c *Client) Stream(ctx context.Context, msg *Message) (<-chan *Message, err
 func (c *Client) Close() error {
 	c.closeOnce.Do(func() {
 		close(c.closed)
+		c.closeErr = c.conn.Close()
+		c.readWg.Wait()
 	})
-	err := c.conn.Close()
-	c.readWg.Wait()
-	return err
+	return c.closeErr
 }

--- a/pkg/agentscope/a2a/grpc/transport_test.go
+++ b/pkg/agentscope/a2a/grpc/transport_test.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -236,6 +237,39 @@ func TestServerShutdownStopsAccepting(t *testing.T) {
 	_, err = NewClient(addr)
 	if err == nil {
 		t.Fatal("expected error connecting to closed server")
+	}
+}
+
+func TestServerCloseUnblocksIdleConnections(t *testing.T) {
+	srv := startTestServer(t, nil)
+	conn, err := net.Dial("tcp", srv.Addr())
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	done := make(chan error, 1)
+	go func() { done <- srv.Close() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close blocked on an idle connection")
+	}
+}
+
+func TestConnTransportReceiveHonorsContextCancellation(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer func() { _ = serverConn.Close() }()
+	defer func() { _ = clientConn.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := newConnTransport(clientConn).Receive(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Receive error = %v, want context.Canceled", err)
 	}
 }
 

--- a/pkg/agentscope/a2a/grpc/transport_test.go
+++ b/pkg/agentscope/a2a/grpc/transport_test.go
@@ -273,6 +273,79 @@ func TestConnTransportReceiveHonorsContextCancellation(t *testing.T) {
 	}
 }
 
+func TestResponseClaimDoesNotDeleteReplacement(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer func() { _ = serverConn.Close() }()
+	// An unbuffered old receiver pauses delivery after the response is claimed,
+	// making replacement of its registry entry deterministic.
+	old := make(chan *Message)
+	c := &Client{
+		conn:    clientConn,
+		t:       newConnTransport(clientConn),
+		pending: map[string]chan *Message{"retry": old},
+		streams: make(map[string]chan *Message),
+		closed:  make(chan struct{}),
+	}
+	c.readWg.Add(1)
+	go c.readLoop()
+	t.Cleanup(func() {
+		// Release a blocked old delivery even when an assertion fails.
+		go func() {
+			for range old {
+			}
+		}()
+		_ = c.Close()
+	})
+	encoder := json.NewEncoder(serverConn)
+	if err := encoder.Encode(&Message{ID: "retry", Method: "old"}); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		c.mu.Lock()
+		claimed := c.pending["retry"] == nil
+		c.mu.Unlock()
+		if claimed {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("response must be removed from the registry before delivery")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	replacement := make(chan *Message, 1)
+	c.mu.Lock()
+	c.pending["retry"] = replacement
+	c.mu.Unlock()
+	<-old
+	if err := encoder.Encode(&Message{ID: "retry", Method: "new"}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case resp := <-replacement:
+		if resp == nil || resp.Method != "new" {
+			t.Fatalf("wrong retry response: %v", resp)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("old response removed the replacement request")
+	}
+}
+
+func TestClientRejectsCrossModeDuplicateIDs(t *testing.T) {
+	c := &Client{
+		pending: make(map[string]chan *Message),
+		streams: map[string]chan *Message{"shared": make(chan *Message, 1)},
+	}
+	if _, err := c.Send(context.Background(), &Message{ID: "shared"}); err == nil {
+		t.Fatal("Send accepted an active stream ID")
+	}
+	delete(c.streams, "shared")
+	c.pending["shared"] = make(chan *Message, 1)
+	if _, err := c.Stream(context.Background(), &Message{ID: "shared"}); err == nil {
+		t.Fatal("Stream accepted an active request ID")
+	}
+}
+
 func TestStreaming(t *testing.T) {
 	// Create a server that manually streams responses
 	ln, err := listenAndServeStreaming(t)

--- a/pkg/agentscope/agent/loop_bridge.go
+++ b/pkg/agentscope/agent/loop_bridge.go
@@ -74,12 +74,12 @@ type toolExecutorAdapter struct {
 }
 
 func (t *toolExecutorAdapter) Execute(ctx context.Context, call message.ToolCallBlock) (*tool.ToolResponse, error) { //nolint:gocritic // interface
-	resolved := t.agent.toolkit.Get(call.Name)
-	if resolved != nil && resolved.IsExternalTool() {
-		return tool.NewErrorResponse(fmt.Errorf("tool %q requires external execution; use UnifiedAgent.ReplyStream", call.Name)), nil
-	}
-	core := func(ctx context.Context, _ *middleware.ActingInput) (*tool.ToolResponse, error) {
-		return t.orchestrator.Execute(ctx, call)
+	core := func(ctx context.Context, input *middleware.ActingInput) (*tool.ToolResponse, error) {
+		resolved := t.agent.toolkit.Get(input.ToolCall.Name)
+		if resolved != nil && resolved.IsExternalTool() {
+			return tool.NewErrorResponse(fmt.Errorf("tool %q requires external execution; use UnifiedAgent.ReplyStream", input.ToolCall.Name)), nil
+		}
+		return t.orchestrator.Execute(ctx, input.ToolCall)
 	}
 	handler := core
 	if len(t.agent.middlewares) > 0 {

--- a/pkg/agentscope/agent/loop_bridge.go
+++ b/pkg/agentscope/agent/loop_bridge.go
@@ -2,9 +2,11 @@ package agent
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/loop"
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/message"
+	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/middleware"
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/model"
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/tool"
 )
@@ -28,9 +30,16 @@ func NewUnifiedAgentRunner(agent *UnifiedAgent, hooks ...loop.Hook) *UnifiedAgen
 // LoopOptions returns loop.Option values for configuring a loop.Loop that
 // delegates model calls and tool execution to the underlying UnifiedAgent.
 func (r *UnifiedAgentRunner) LoopOptions() []loop.Option {
+	executor := &toolExecutorAdapter{
+		agent: r.agent,
+		orchestrator: tool.NewOrchestrator(tool.OrchestratorConfig{
+			Toolkit:    r.agent.toolkit,
+			PermEngine: r.agent.engine,
+		}),
+	}
 	opts := []loop.Option{
 		loop.WithModelCaller(&modelCallerAdapter{agent: r.agent}),
-		loop.WithToolExecutor(&toolExecutorAdapter{agent: r.agent}),
+		loop.WithToolExecutor(executor),
 		loop.WithSchemaProvider(r.agent.toolkit),
 		loop.WithMaxIters(r.agent.reactCfg.MaxIters),
 		loop.WithSystemPrompt(r.agent.systemPrompt),
@@ -55,16 +64,28 @@ func (m *modelCallerAdapter) Call(ctx context.Context, msgs []*message.Msg, tool
 	return m.agent.callModel(ctx, msgs, opts)
 }
 
-// toolExecutorAdapter implements loop.ToolExecutor by delegating to the
-// agent's toolkit. This is a simplified path without permission checks or
-// HITL — those features stay in UnifiedAgent.ReplyStream for the full
-// experience.
+// toolExecutorAdapter implements loop.ToolExecutor through the same permission
+// and acting-middleware layers used by UnifiedAgent. The loop protocol has no
+// HITL event channel, so confirmation-required and external tools fail closed;
+// callers that need interactive approval must use UnifiedAgent.ReplyStream.
 type toolExecutorAdapter struct {
-	agent *UnifiedAgent
+	agent        *UnifiedAgent
+	orchestrator *tool.Orchestrator
 }
 
 func (t *toolExecutorAdapter) Execute(ctx context.Context, call message.ToolCallBlock) (*tool.ToolResponse, error) { //nolint:gocritic // interface
-	return t.agent.toolkit.CallToolFromBlock(ctx, &call)
+	resolved := t.agent.toolkit.Get(call.Name)
+	if resolved != nil && resolved.IsExternalTool() {
+		return tool.NewErrorResponse(fmt.Errorf("tool %q requires external execution; use UnifiedAgent.ReplyStream", call.Name)), nil
+	}
+	core := func(ctx context.Context, _ *middleware.ActingInput) (*tool.ToolResponse, error) {
+		return t.orchestrator.Execute(ctx, call)
+	}
+	handler := core
+	if len(t.agent.middlewares) > 0 {
+		handler = middleware.BuildActingChain(t.agent.middlewares, core)
+	}
+	return handler(ctx, &middleware.ActingInput{AgentName: t.agent.name, ToolCall: call})
 }
 
 func (t *toolExecutorAdapter) BatchExecute(ctx context.Context, calls []message.ToolCallBlock) []*loop.ToolResult {

--- a/pkg/agentscope/agent/loop_bridge_test.go
+++ b/pkg/agentscope/agent/loop_bridge_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/loop"
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/message"
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/metrics"
+	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/middleware"
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/model"
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/permission"
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/tool"
@@ -118,6 +119,40 @@ func TestUnifiedAgentRunnerFailsClosedWhenToolNeedsConfirmation(t *testing.T) {
 	if got := result.GetTextContent(); got != "not executed" {
 		t.Fatalf("result = %q, want %q", got, "not executed")
 	}
+}
+
+func TestLoopBridgeUsesMiddlewareRewrittenInput(t *testing.T) {
+	var got string
+	echo := tool.NewFunctionTool("echo", "echo", nil,
+		func(_ context.Context, input map[string]any) (any, error) {
+			got, _ = input["text"].(string)
+			return got, nil
+		})
+	a := NewUnifiedAgent("bot", "prompt", &mockChatModel{},
+		WithToolkit(tool.NewToolkit(echo)),
+		WithMiddlewares(&rewriteActingInput{}),
+		WithPermissionContext(permission.NewContext(permission.ModeBypass)),
+	)
+	var cfg loop.Config
+	for _, opt := range NewUnifiedAgentRunner(a).LoopOptions() {
+		opt(&cfg)
+	}
+	_, err := cfg.ToolExecutor.Execute(context.Background(), message.ToolCallBlock{
+		Type: "tool_use", ID: "rewrite", Name: "echo", Input: `{"text":"original"}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "sanitized" {
+		t.Fatalf("tool received %q, want middleware-rewritten input", got)
+	}
+}
+
+type rewriteActingInput struct{ middleware.BaseMiddleware }
+
+func (m *rewriteActingInput) OnActing(ctx context.Context, input *middleware.ActingInput, next middleware.ActingHandler) (*tool.ToolResponse, error) {
+	input.ToolCall.Input = `{"text":"sanitized"}`
+	return next(ctx, input)
 }
 
 // --- In-memory metrics provider for testing ---

--- a/pkg/agentscope/agent/loop_bridge_test.go
+++ b/pkg/agentscope/agent/loop_bridge_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/message"
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/metrics"
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/model"
+	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/permission"
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/tool"
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/tracing"
 )
@@ -85,6 +86,36 @@ func TestUnifiedAgentRunnerWithToolCall(t *testing.T) {
 	}
 	if mock.callCount != 2 {
 		t.Errorf("model called %d times, want 2", mock.callCount)
+	}
+}
+
+func TestUnifiedAgentRunnerFailsClosedWhenToolNeedsConfirmation(t *testing.T) {
+	var executions atomic.Int64
+	dangerous := tool.NewFunctionTool("dangerous", "must be confirmed", nil,
+		func(_ context.Context, _ map[string]any) (any, error) {
+			executions.Add(1)
+			return "executed", nil
+		})
+	mock := &mockChatModel{responses: []model.ChatResponse{
+		{Content: []message.ContentBlock{message.ToolCallBlock{
+			Type: "tool_use", ID: "tc-denied", Name: "dangerous", Input: `{}`,
+		}}, IsLast: true},
+		{Content: []message.ContentBlock{message.TextBlock{Type: "text", Text: "not executed"}}, IsLast: true},
+	}}
+	a := NewUnifiedAgent("bot", "prompt", mock,
+		WithToolkit(tool.NewToolkit(dangerous)),
+		WithPermissionContext(permission.NewContext(permission.ModeDefault)),
+	)
+
+	result, err := loop.New(NewUnifiedAgentRunner(a).LoopOptions()...).RunSync(context.Background(), "run it")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if executions.Load() != 0 {
+		t.Fatalf("dangerous tool executed %d times without confirmation", executions.Load())
+	}
+	if got := result.GetTextContent(); got != "not executed" {
+		t.Fatalf("result = %q, want %q", got, "not executed")
 	}
 }
 

--- a/pkg/agentscope/agent/loop_bridge_test.go
+++ b/pkg/agentscope/agent/loop_bridge_test.go
@@ -99,6 +99,7 @@ func TestUnifiedAgentRunnerFailsClosedWhenToolNeedsConfirmation(t *testing.T) {
 	mock := &mockChatModel{responses: []model.ChatResponse{
 		{Content: []message.ContentBlock{message.ToolCallBlock{
 			Type: "tool_use", ID: "tc-denied", Name: "dangerous", Input: `{}`,
+			State: message.ToolCallPending,
 		}}, IsLast: true},
 		{Content: []message.ContentBlock{message.TextBlock{Type: "text", Text: "not executed"}}, IsLast: true},
 	}}

--- a/pkg/agentscope/loop/interfaces.go
+++ b/pkg/agentscope/loop/interfaces.go
@@ -32,12 +32,10 @@ type ToolExecutor interface {
 	BatchExecute(ctx context.Context, calls []message.ToolCallBlock) []*ToolResult
 }
 
-// ToolResult pairs a tool call with its execution result or error.
-type ToolResult struct {
-	Call     message.ToolCallBlock
-	Response *tool.ToolResponse
-	Err      error
-}
+// ToolResult pairs a tool call with its execution result or error. It aliases
+// tool.OrchestratorResult so tool.Orchestrator can implement ToolExecutor
+// without introducing a tool -> loop import cycle.
+type ToolResult = tool.OrchestratorResult
 
 // ContextManager manages the conversation message history.
 type ContextManager interface {

--- a/pkg/agentscope/loop/loop.go
+++ b/pkg/agentscope/loop/loop.go
@@ -347,6 +347,10 @@ func (l *Loop) prependSystemPrompt() {
 	}
 	sysMsg := message.SystemMsg("system", l.cfg.SystemPrompt)
 	dcm.mu.Lock()
+	if len(dcm.messages) > 0 && dcm.messages[0].Role == message.RoleSystem {
+		dcm.mu.Unlock()
+		return
+	}
 	dcm.messages = append([]*message.Msg{sysMsg}, dcm.messages...)
 	dcm.mu.Unlock()
 }

--- a/pkg/agentscope/loop/orchestrator_integration_test.go
+++ b/pkg/agentscope/loop/orchestrator_integration_test.go
@@ -1,0 +1,19 @@
+package loop
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/message"
+	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/tool"
+)
+
+func TestOrchestratorImplementsToolExecutor(t *testing.T) {
+	o := tool.NewOrchestrator(tool.OrchestratorConfig{Toolkit: tool.NewToolkit()})
+	var executor ToolExecutor = o.AsToolExecutor()
+
+	results := executor.BatchExecute(context.Background(), []message.ToolCallBlock{{Name: "missing", Input: `{}`}})
+	if len(results) != 1 || results[0].Err == nil {
+		t.Fatalf("expected one missing-tool error result, got %#v", results)
+	}
+}

--- a/pkg/agentscope/runtime/session_engine.go
+++ b/pkg/agentscope/runtime/session_engine.go
@@ -12,24 +12,27 @@ import (
 
 // SessionEngineConfig holds the configuration for creating a SessionEngine.
 type SessionEngineConfig struct {
-	LoopOptions []loop.Option
-	Budget      Budget
-	Store       SessionStore
+	LoopOptions    []loop.Option
+	ContextManager loop.ContextManager
+	Budget         Budget
+	Store          SessionStore
 }
 
 // SessionEngine orchestrates a multi-turn session. It wires together a Loop,
 // BudgetTracker, SessionHookManager, and SessionStore to manage the full
 // lifecycle of a user session.
 type SessionEngine struct {
-	mu         sync.RWMutex
-	id         string
-	loopOpts   []loop.Option
-	budget     *BudgetTracker
-	hooks      *SessionHookManager
-	agents     *AgentManager
-	store      SessionStore
-	cancelFunc context.CancelFunc
-	state      *SessionState
+	mu             sync.RWMutex
+	turnMu         sync.Mutex
+	id             string
+	loopOpts       []loop.Option
+	contextManager loop.ContextManager
+	budget         *BudgetTracker
+	hooks          *SessionHookManager
+	agents         *AgentManager
+	store          SessionStore
+	cancelFunc     context.CancelFunc
+	state          *SessionState
 }
 
 // NewSessionEngine creates a new SessionEngine with a unique ID and the given
@@ -45,14 +48,19 @@ func NewSessionEngine(cfg SessionEngineConfig) *SessionEngine {
 
 	bt := NewBudgetTracker(cfg.Budget)
 	hooks := NewSessionHookManager()
+	contextManager := cfg.ContextManager
+	if contextManager == nil {
+		contextManager = loop.NewDefaultContextManager()
+	}
 
 	se := &SessionEngine{
-		id:       id,
-		loopOpts: cfg.LoopOptions,
-		budget:   bt,
-		hooks:    hooks,
-		agents:   NewAgentManager(bt, hooks),
-		store:    store,
+		id:             id,
+		loopOpts:       append([]loop.Option(nil), cfg.LoopOptions...),
+		contextManager: contextManager,
+		budget:         bt,
+		hooks:          hooks,
+		agents:         NewAgentManager(bt, hooks),
+		store:          store,
 		state: &SessionState{
 			ID:        id,
 			Metadata:  make(map[string]any),
@@ -79,22 +87,33 @@ func (se *SessionEngine) Agents() *AgentManager { return se.agents }
 // channel. The channel is closed when the turn finishes. Session hooks are
 // fired around the turn execution, and state is persisted afterwards.
 func (se *SessionEngine) SubmitMessage(ctx context.Context, input string) <-chan event.Event {
-	se.mu.Lock()
-	sessionCtx, cancel := context.WithCancel(ctx)
-	se.cancelFunc = cancel
-	se.mu.Unlock()
-
-	l := loop.New(se.loopOpts...)
-	turn := NewTurn(TurnConfig{
-		Loop:   l,
-		Hooks:  se.hooks,
-		Budget: se.budget,
-	})
-
 	out := make(chan event.Event, 64)
 	go func() {
 		defer close(out)
+
+		// A ContextManager is mutable. Serialize turns so concurrent submissions
+		// cannot interleave user/assistant messages in the shared history.
+		se.turnMu.Lock()
+		defer se.turnMu.Unlock()
+
+		sessionCtx, cancel := context.WithCancel(ctx)
+		se.mu.Lock()
+		se.cancelFunc = cancel
+		se.mu.Unlock()
 		defer cancel()
+		defer func() {
+			se.mu.Lock()
+			se.cancelFunc = nil
+			se.mu.Unlock()
+		}()
+
+		loopOpts := append([]loop.Option(nil), se.loopOpts...)
+		loopOpts = append(loopOpts, loop.WithContextManager(se.contextManager))
+		turn := NewTurn(TurnConfig{
+			Loop:   loop.New(loopOpts...),
+			Hooks:  se.hooks,
+			Budget: se.budget,
+		})
 
 		_ = se.hooks.Fire(HookSessionStart, map[string]any{"session_id": se.id})
 
@@ -104,6 +123,7 @@ func (se *SessionEngine) SubmitMessage(ctx context.Context, input string) <-chan
 
 		se.mu.Lock()
 		se.state.UpdatedAt = time.Now()
+		se.state.Messages = se.contextManager.Messages()
 		se.mu.Unlock()
 
 		se.saveState()
@@ -128,13 +148,12 @@ func (se *SessionEngine) Interrupt() {
 func (se *SessionEngine) State() *SessionState {
 	se.mu.RLock()
 	defer se.mu.RUnlock()
-	cp := *se.state
-	return &cp
+	return cloneSessionState(se.state)
 }
 
 func (se *SessionEngine) saveState() {
 	se.mu.RLock()
-	state := se.state
+	state := cloneSessionState(se.state)
 	se.mu.RUnlock()
 
 	if se.store != nil {

--- a/pkg/agentscope/runtime/session_engine.go
+++ b/pkg/agentscope/runtime/session_engine.go
@@ -12,10 +12,9 @@ import (
 
 // SessionEngineConfig holds the configuration for creating a SessionEngine.
 type SessionEngineConfig struct {
-	LoopOptions    []loop.Option
-	ContextManager loop.ContextManager
-	Budget         Budget
-	Store          SessionStore
+	LoopOptions []loop.Option
+	Budget      Budget
+	Store       SessionStore
 }
 
 // SessionEngine orchestrates a multi-turn session. It wires together a Loop,
@@ -25,7 +24,7 @@ type SessionEngine struct {
 	mu             sync.RWMutex
 	turnMu         sync.Mutex
 	id             string
-	loopOpts       []loop.Option
+	loop           *loop.Loop
 	contextManager loop.ContextManager
 	budget         *BudgetTracker
 	hooks          *SessionHookManager
@@ -48,14 +47,21 @@ func NewSessionEngine(cfg SessionEngineConfig) *SessionEngine {
 
 	bt := NewBudgetTracker(cfg.Budget)
 	hooks := NewSessionHookManager()
-	contextManager := cfg.ContextManager
-	if contextManager == nil {
-		contextManager = loop.NewDefaultContextManager()
-	}
+	// Resolve options once and retain the configured manager across turns.
+	// In particular, preserve restored history and custom compression managers.
+	var contextManager loop.ContextManager
+	loopOpts := append([]loop.Option(nil), cfg.LoopOptions...)
+	loopOpts = append(loopOpts, func(c *loop.Config) {
+		if c.ContextManager == nil {
+			c.ContextManager = loop.NewDefaultContextManager()
+		}
+		contextManager = c.ContextManager
+	})
+	sessionLoop := loop.New(loopOpts...)
 
 	se := &SessionEngine{
 		id:             id,
-		loopOpts:       append([]loop.Option(nil), cfg.LoopOptions...),
+		loop:           sessionLoop,
 		contextManager: contextManager,
 		budget:         bt,
 		hooks:          hooks,
@@ -107,10 +113,8 @@ func (se *SessionEngine) SubmitMessage(ctx context.Context, input string) <-chan
 			se.mu.Unlock()
 		}()
 
-		loopOpts := append([]loop.Option(nil), se.loopOpts...)
-		loopOpts = append(loopOpts, loop.WithContextManager(se.contextManager))
 		turn := NewTurn(TurnConfig{
-			Loop:   loop.New(loopOpts...),
+			Loop:   se.loop,
 			Hooks:  se.hooks,
 			Budget: se.budget,
 		})

--- a/pkg/agentscope/runtime/session_engine_test.go
+++ b/pkg/agentscope/runtime/session_engine_test.go
@@ -85,6 +85,30 @@ func TestSessionEnginePreservesHistoryAcrossTurns(t *testing.T) {
 	}
 }
 
+func TestSessionEngineUsesConfiguredContextManager(t *testing.T) {
+	cm := loop.NewDefaultContextManager()
+	cm.Append(message.UserMsg("user", "restored history"))
+	mc := &historyModelCaller{}
+	se := NewSessionEngine(SessionEngineConfig{
+		LoopOptions: []loop.Option{
+			loop.WithModelCaller(mc),
+			loop.WithContextManager(cm),
+		},
+	})
+	for range se.SubmitMessage(context.Background(), "first") {
+	}
+	for range se.SubmitMessage(context.Background(), "second") {
+	}
+	if got := len(cm.Messages()); got != 5 {
+		t.Fatalf("configured manager has %d messages, want restored history and two turns", got)
+	}
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	if len(mc.calls) != 2 || len(mc.calls[0]) != 2 || len(mc.calls[1]) != 4 {
+		t.Fatalf("model did not receive restored and accumulated history: %v", mc.calls)
+	}
+}
+
 func TestSessionEngineID(t *testing.T) {
 	se := NewSessionEngine(SessionEngineConfig{})
 	if se.ID() == "" {

--- a/pkg/agentscope/runtime/session_engine_test.go
+++ b/pkg/agentscope/runtime/session_engine_test.go
@@ -2,6 +2,8 @@ package runtime
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,6 +42,46 @@ func TestSessionEngineSubmitMessage(t *testing.T) {
 	}
 	if !hasReplyEnd {
 		t.Error("missing ReplyEnd event")
+	}
+}
+
+func TestSessionEnginePreservesHistoryAcrossTurns(t *testing.T) {
+	mc := &historyModelCaller{}
+	se := NewSessionEngine(SessionEngineConfig{
+		LoopOptions: []loop.Option{
+			loop.WithModelCaller(mc),
+			loop.WithMaxIters(1),
+			loop.WithSystemPrompt("stay concise"),
+		},
+	})
+
+	for range se.SubmitMessage(context.Background(), "first") {
+	}
+	for range se.SubmitMessage(context.Background(), "second") {
+	}
+
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	if len(mc.calls) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(mc.calls))
+	}
+	got := mc.calls[1]
+	wantRoles := []message.Role{
+		message.RoleSystem,
+		message.RoleUser,
+		message.RoleAssistant,
+		message.RoleUser,
+	}
+	if len(got) != len(wantRoles) {
+		t.Fatalf("second-turn history has %d messages, want %d", len(got), len(wantRoles))
+	}
+	for i, want := range wantRoles {
+		if got[i].Role != want {
+			t.Errorf("history[%d].Role = %q, want %q", i, got[i].Role, want)
+		}
+	}
+	if state := se.State(); len(state.Messages) != 5 {
+		t.Fatalf("persisted history has %d messages, want 5", len(state.Messages))
 	}
 }
 
@@ -181,6 +223,22 @@ type seMockModelCaller struct {
 
 func (m *seMockModelCaller) Call(_ context.Context, _ []*message.Msg, _ []model.ToolSchema) (*model.ChatResponse, error) {
 	return m.resp, nil
+}
+
+type historyModelCaller struct {
+	mu    sync.Mutex
+	calls [][]*message.Msg
+}
+
+func (m *historyModelCaller) Call(_ context.Context, messages []*message.Msg, _ []model.ToolSchema) (*model.ChatResponse, error) {
+	m.mu.Lock()
+	m.calls = append(m.calls, append([]*message.Msg(nil), messages...))
+	n := len(m.calls)
+	m.mu.Unlock()
+	return &model.ChatResponse{
+		Content: []message.ContentBlock{message.TextBlock{Type: "text", Text: fmt.Sprintf("response %d", n)}},
+		IsLast:  true,
+	}, nil
 }
 
 type blockingModelCaller struct {

--- a/pkg/agentscope/runtime/session_store.go
+++ b/pkg/agentscope/runtime/session_store.go
@@ -7,14 +7,33 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/internal/fsutil"
+	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/message"
 )
 
 // SessionState represents the persisted state of a session.
 type SessionState struct {
 	ID        string         `json:"id"`
 	Metadata  map[string]any `json:"metadata,omitempty"`
+	Messages  []*message.Msg `json:"messages,omitempty"`
 	CreatedAt time.Time      `json:"created_at"`
 	UpdatedAt time.Time      `json:"updated_at"`
+}
+
+func cloneSessionState(state *SessionState) *SessionState {
+	if state == nil {
+		return nil
+	}
+	cp := *state
+	cp.Messages = append([]*message.Msg(nil), state.Messages...)
+	if state.Metadata != nil {
+		cp.Metadata = make(map[string]any, len(state.Metadata))
+		for key, value := range state.Metadata {
+			cp.Metadata[key] = value
+		}
+	}
+	return &cp
 }
 
 // SessionStore defines the interface for session persistence.
@@ -41,8 +60,7 @@ func NewInMemorySessionStore() *InMemorySessionStore {
 func (s *InMemorySessionStore) Save(_ string, state *SessionState) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	cp := *state
-	s.store[state.ID] = &cp
+	s.store[state.ID] = cloneSessionState(state)
 	return nil
 }
 
@@ -54,8 +72,7 @@ func (s *InMemorySessionStore) Load(id string) (*SessionState, error) {
 	if !ok {
 		return nil, fmt.Errorf("session %q not found", id)
 	}
-	cp := *state
-	return &cp, nil
+	return cloneSessionState(state), nil
 }
 
 // Delete removes the session state by ID.
@@ -99,7 +116,7 @@ func (s *FileSessionStore) Save(_ string, state *SessionState) error {
 		return fmt.Errorf("session store: marshal: %w", err)
 	}
 	path := filepath.Join(dir, "session.json")
-	return os.WriteFile(path, data, 0o644)
+	return fsutil.WriteFileAtomic(path, data, 0o644)
 }
 
 // Load reads the session state from disk.

--- a/pkg/agentscope/runtime/turn.go
+++ b/pkg/agentscope/runtime/turn.go
@@ -74,7 +74,8 @@ func (t *Turn) run(ctx context.Context, input string, out chan<- event.Event) {
 	// and MaxDuration were dead config on this path).
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	for ev := range t.cfg.Loop.Run(runCtx, input) {
+	loopEvents := t.cfg.Loop.Run(runCtx, input)
+	for ev := range loopEvents {
 		emitEvent(ctx, out, ev)
 		if t.cfg.Budget == nil {
 			continue
@@ -89,6 +90,10 @@ func (t *Turn) run(ctx context.Context, input string, out chan<- event.Event) {
 			emitEvent(ctx, out, event.NewCustomEvent("", "turn.budget_exceeded",
 				map[string]any{"error": "budget exceeded (tokens or duration)"}))
 			cancel()
+			// Wait for the loop to stop mutating history before the session
+			// persists it or starts the next turn.
+			for range loopEvents {
+			}
 			break
 		}
 	}

--- a/pkg/agentscope/runtime/turn_test.go
+++ b/pkg/agentscope/runtime/turn_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/event"
 	"github.com/alanfokco/agentscope-go/v2/pkg/agentscope/loop"
@@ -146,6 +147,69 @@ func TestTurnNilLoop(t *testing.T) {
 	if !hasError {
 		t.Error("expected turn.error event when loop is nil")
 	}
+}
+
+func TestTurnBudgetWaitsForHistoryMutation(t *testing.T) {
+	cm := &gatedContextManager{
+		DefaultContextManager: loop.NewDefaultContextManager(),
+		entered:               make(chan struct{}),
+		release:               make(chan struct{}),
+	}
+	mc := &turnMockModelCaller{resp: &model.ChatResponse{
+		Content: []message.ContentBlock{message.TextBlock{Type: "text", Text: "response"}},
+		Usage:   &model.ChatUsage{InputTokens: 10},
+	}}
+	turn := NewTurn(TurnConfig{
+		Loop:   loop.New(loop.WithModelCaller(mc), loop.WithContextManager(cm)),
+		Budget: NewBudgetTracker(Budget{MaxTokens: 1}),
+	})
+	done := make(chan struct{})
+	budgetExceeded := make(chan struct{})
+	go func() {
+		defer close(done)
+		for ev := range turn.Run(context.Background(), "test") {
+			if ce, ok := ev.(event.CustomEvent); ok && ce.Name == "turn.budget_exceeded" {
+				close(budgetExceeded)
+			}
+		}
+	}()
+	defer func() {
+		close(cm.release)
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Error("turn did not stop after releasing history mutation")
+		}
+	}()
+	select {
+	case <-cm.entered:
+	case <-time.After(time.Second):
+		t.Fatal("loop did not reach history mutation")
+	}
+	select {
+	case <-budgetExceeded:
+	case <-time.After(time.Second):
+		t.Fatal("token budget did not stop the turn")
+	}
+	select {
+	case <-done:
+		t.Fatal("turn returned while the loop was still mutating shared history")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+type gatedContextManager struct {
+	*loop.DefaultContextManager
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (m *gatedContextManager) Append(msg *message.Msg) {
+	if msg.Role == message.RoleAssistant {
+		close(m.entered)
+		<-m.release
+	}
+	m.DefaultContextManager.Append(msg)
 }
 
 // --- Mock ---

--- a/pkg/agentscope/tool/builtin_bash.go
+++ b/pkg/agentscope/tool/builtin_bash.go
@@ -261,7 +261,11 @@ func (t *bashTool) runCommand(ctx context.Context, cmdStr string, timeoutMs int)
 		if max := t.maxOutputBytes; max > 0 && len(out) > max {
 			out = out[:max] + "\n... [output truncated]"
 		}
-		return NewTextResponse(out), nil
+		resp := NewTextResponse(out)
+		if res.ExitCode != 0 {
+			resp.State = message.ToolResultError
+		}
+		return resp, nil
 	}
 
 	args := platform.Detect().DeriveExecArgs(cmdStr)
@@ -342,7 +346,11 @@ func (t *bashTool) runCommand(ctx context.Context, cmdStr string, timeoutMs int)
 	}
 
 	b, _ := json.Marshal(result)
-	return NewTextResponse(string(b)), nil
+	resp := NewTextResponse(string(b))
+	if exitCode != 0 || waitErr != nil {
+		resp.State = message.ToolResultError
+	}
+	return resp, nil
 }
 
 // CheckPermissions implements a 7-step permission chain:

--- a/pkg/agentscope/tool/builtin_enhanced_test.go
+++ b/pkg/agentscope/tool/builtin_enhanced_test.go
@@ -684,6 +684,24 @@ func TestBashTool_StreamingNonZeroExit(t *testing.T) {
 	}
 }
 
+func TestBashTool_SynchronousNonZeroExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix shell")
+	}
+	resp, err := BashTool().Execute(context.Background(), map[string]any{
+		"command": "echo fail; exit 7",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.State != message.ToolResultError {
+		t.Fatalf("state = %s, want error for non-zero exit", resp.State)
+	}
+	if text := getResponseText(resp); !strings.Contains(text, `"exit_code":7`) {
+		t.Fatalf("response should preserve the exit code, got %q", text)
+	}
+}
+
 func TestBashTool_CollectStream(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("requires Unix shell")

--- a/pkg/agentscope/tool/covered_regressions_test.go
+++ b/pkg/agentscope/tool/covered_regressions_test.go
@@ -70,3 +70,32 @@ func TestFunctionTool_CustomSchemaHonored(t *testing.T) {
 		t.Errorf("tool schema parameters = %s, want the custom schema verbatim", schemas[0].Function.Parameters)
 	}
 }
+
+func TestToolkitRejectsDuplicateToolNames(t *testing.T) {
+	tk := NewToolkit(NewFunctionTool("search", "first", nil,
+		func(_ context.Context, _ map[string]any) (any, error) { return "first", nil }))
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected AddGroup to reject a case-insensitive duplicate tool name")
+		}
+	}()
+	tk.AddGroup("other", NewFunctionTool("SEARCH", "second", nil,
+		func(_ context.Context, _ map[string]any) (any, error) { return "second", nil }))
+}
+
+func TestToolkitSchemasHaveDeterministicGroupOrder(t *testing.T) {
+	tk := NewToolkit()
+	tk.AddGroup("z-last", NewFunctionTool("z", "z", nil,
+		func(_ context.Context, _ map[string]any) (any, error) { return "z", nil }))
+	tk.AddGroup("a-first", NewFunctionTool("a", "a", nil,
+		func(_ context.Context, _ map[string]any) (any, error) { return "a", nil }))
+
+	schemas := tk.GetToolSchemas()
+	if len(schemas) != 2 {
+		t.Fatalf("expected 2 schemas, got %d", len(schemas))
+	}
+	if schemas[0].Function.Name != "a" || schemas[1].Function.Name != "z" {
+		t.Fatalf("schema order = [%s, %s], want [a, z]", schemas[0].Function.Name, schemas[1].Function.Name)
+	}
+}

--- a/pkg/agentscope/tool/orchestrator.go
+++ b/pkg/agentscope/tool/orchestrator.go
@@ -177,7 +177,7 @@ func (o *Orchestrator) Execute(ctx context.Context, call message.ToolCallBlock) 
 		execCtx, cancel = context.WithTimeout(execCtx, o.defaultToolTimeout)
 		defer cancel()
 	}
-	resp, err := o.toolkit.CallTool(execCtx, call.Name, input)
+	resp, err := o.toolkit.callResolvedTool(execCtx, call.Name, input, t)
 	elapsed := time.Since(start)
 
 	// 6. Audit the execution result.
@@ -354,30 +354,7 @@ func policyDeniedResponse(msg string) *ToolResponse {
 	}
 }
 
-// toolExecutorAdapter wraps an Orchestrator with method signatures matching
-// loop.ToolExecutor. Since the tool package cannot import loop (circular
-// dependency), this adapter is structurally compatible but does not reference
-// loop types directly. The loop package can assign it via interface assertion.
-type toolExecutorAdapter struct {
-	o *Orchestrator
-}
-
-// Execute delegates to the underlying Orchestrator. The signature matches
-// loop.ToolExecutor.Execute.
-func (a *toolExecutorAdapter) Execute(ctx context.Context, call message.ToolCallBlock) (*ToolResponse, error) { //nolint:gocritic // interface
-	return a.o.Execute(ctx, call)
-}
-
-// BatchExecute delegates to the underlying Orchestrator. Returns
-// []*OrchestratorResult which has the same fields as loop.ToolResult.
-func (a *toolExecutorAdapter) BatchExecute(ctx context.Context, calls []message.ToolCallBlock) []*OrchestratorResult {
-	return a.o.BatchExecute(ctx, calls)
-}
-
-// AsToolExecutor returns an adapter whose Execute and BatchExecute methods
-// match the loop.ToolExecutor interface signatures (modulo return types for
-// BatchExecute due to circular import constraints). Use a type assertion in
-// the loop package to satisfy the interface.
-func (o *Orchestrator) AsToolExecutor() *toolExecutorAdapter {
-	return &toolExecutorAdapter{o: o}
-}
+// AsToolExecutor returns the orchestrator itself. loop.ToolResult aliases
+// OrchestratorResult, so the orchestrator satisfies loop.ToolExecutor without
+// a circular import or a signature-changing adapter.
+func (o *Orchestrator) AsToolExecutor() *Orchestrator { return o }

--- a/pkg/agentscope/tool/tool.go
+++ b/pkg/agentscope/tool/tool.go
@@ -170,6 +170,9 @@ type Toolkit struct {
 func NewToolkit(tools ...Tool) *Toolkit {
 	tk := &Toolkit{groups: make(map[string]*ToolGroup)}
 	if len(tools) > 0 {
+		if err := validateUniqueToolNames(tools); err != nil {
+			panic(err)
+		}
 		tk.groups["basic"] = &ToolGroup{
 			GroupName: "basic",
 			Tools:     tools,
@@ -183,6 +186,9 @@ func NewToolkit(tools ...Tool) *Toolkit {
 func (tk *Toolkit) AddGroup(name string, tools ...Tool) {
 	tk.mu.Lock()
 	defer tk.mu.Unlock()
+	if err := tk.validateGroupToolsLocked(name, tools); err != nil {
+		panic(err)
+	}
 	tk.groups[name] = &ToolGroup{
 		GroupName: name,
 		Tools:     tools,
@@ -242,7 +248,8 @@ func (tk *Toolkit) GetToolSchemas() []model.ToolSchema {
 	defer tk.mu.RUnlock()
 
 	var schemas []model.ToolSchema
-	for _, g := range tk.groups {
+	for _, groupName := range sortedGroupNames(tk.groups) {
+		g := tk.groups[groupName]
 		if !g.Active {
 			continue
 		}
@@ -278,7 +285,13 @@ func (tk *Toolkit) CallTool(ctx context.Context, name string, input map[string]a
 		}
 		return nil, &agenterrors.ToolNotFoundError{ToolName: name}
 	}
+	return tk.callResolvedTool(ctx, name, input, t)
+}
 
+// callResolvedTool executes a previously resolved tool instance. Keeping
+// resolution separate lets callers such as Orchestrator permission-check and
+// execute exactly the same object instead of looking it up twice.
+func (tk *Toolkit) callResolvedTool(ctx context.Context, name string, input map[string]any, t Tool) (*ToolResponse, error) {
 	// Validate input against schema before execution
 	if schema := t.InputSchema(); len(schema) > 0 {
 		if err := ValidateInput(schema, input); err != nil {
@@ -358,7 +371,8 @@ func (tk *Toolkit) findTool(name string) Tool {
 // lowercase names (e.g. "bash") still find the renamed tools (e.g. "Bash").
 func (tk *Toolkit) findToolWithGroup(name string) (Tool, string) {
 	inactiveGroup := ""
-	for _, g := range tk.groups {
+	for _, groupName := range sortedGroupNames(tk.groups) {
+		g := tk.groups[groupName]
 		for _, t := range g.Tools {
 			if t.Name() == name {
 				if g.Active {
@@ -374,7 +388,8 @@ func (tk *Toolkit) findToolWithGroup(name string) (Tool, string) {
 
 	// Case-insensitive fallback: compare lowercased names
 	lowerName := strings.ToLower(name)
-	for _, g := range tk.groups {
+	for _, groupName := range sortedGroupNames(tk.groups) {
+		g := tk.groups[groupName]
 		for _, t := range g.Tools {
 			if strings.ToLower(t.Name()) == lowerName {
 				if g.Active {
@@ -413,7 +428,8 @@ func (tk *Toolkit) GetToolSchemasForGroups(groups ...string) []model.ToolSchema 
 	}
 
 	var schemas []model.ToolSchema
-	for _, g := range tk.groups {
+	for _, groupName := range sortedGroupNames(tk.groups) {
+		g := tk.groups[groupName]
 		if !g.Active || !want[g.GroupName] {
 			continue
 		}
@@ -438,6 +454,58 @@ func (tk *Toolkit) GetToolSchemasForGroups(groups ...string) []model.ToolSchema 
 // AddMiddleware appends a tool-level middleware to the BaseTool.
 func (b *BaseTool) AddMiddleware(mw ToolMiddleware) {
 	b.Middlewares = append(b.Middlewares, mw)
+}
+
+func sortedGroupNames(groups map[string]*ToolGroup) []string {
+	names := make([]string, 0, len(groups))
+	for name := range groups {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func validateUniqueToolNames(tools []Tool) error {
+	seen := make(map[string]string, len(tools))
+	for _, t := range tools {
+		if t == nil {
+			return fmt.Errorf("toolkit: nil tool")
+		}
+		name := strings.TrimSpace(t.Name())
+		if name == "" {
+			return fmt.Errorf("toolkit: tool name must not be empty")
+		}
+		key := strings.ToLower(name)
+		if previous, ok := seen[key]; ok {
+			return fmt.Errorf("toolkit: duplicate tool name %q conflicts with %q", name, previous)
+		}
+		seen[key] = name
+	}
+	return nil
+}
+
+// validateGroupToolsLocked rejects global, case-insensitive name collisions.
+// The caller must hold tk.mu for writing. Replacing a group is allowed as long
+// as its replacement tools do not collide with tools in other groups.
+func (tk *Toolkit) validateGroupToolsLocked(replacingGroup string, tools []Tool) error {
+	if err := validateUniqueToolNames(tools); err != nil {
+		return err
+	}
+	existing := make(map[string]string)
+	for groupName, group := range tk.groups {
+		if groupName == replacingGroup {
+			continue
+		}
+		for _, t := range group.Tools {
+			existing[strings.ToLower(t.Name())] = t.Name()
+		}
+	}
+	for _, t := range tools {
+		if previous, ok := existing[strings.ToLower(t.Name())]; ok {
+			return fmt.Errorf("toolkit: duplicate tool name %q conflicts with %q", t.Name(), previous)
+		}
+	}
+	return nil
 }
 
 // toolMiddlewarer is implemented by tools that carry their own middleware chain.

--- a/pkg/agentscope/wasm/cli_runtime.go
+++ b/pkg/agentscope/wasm/cli_runtime.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -87,9 +89,20 @@ func (r *CLIRuntime) Execute(ctx context.Context, req *ExecRequest) (*ExecResult
 	if memMax == 0 {
 		memMax = DefaultMemoryMax
 	}
+	effective := *req
+	effective.MemoryMax = memMax
+	if effective.Fuel == 0 {
+		effective.Fuel = DefaultFuel
+	}
+	if effective.MaxOutputBytes == 0 {
+		effective.MaxOutputBytes = DefaultOutputMax
+	}
+	if err := r.validateLimits(&effective); err != nil {
+		return nil, err
+	}
 
 	// Build the command.
-	args := r.buildArgs(req, memMax)
+	args := r.buildArgs(&effective, memMax)
 
 	// Apply timeout to context.
 	ctx, cancel := context.WithTimeout(ctx, timeout)
@@ -98,19 +111,21 @@ func (r *CLIRuntime) Execute(ctx context.Context, req *ExecRequest) (*ExecResult
 	cmd := exec.CommandContext(ctx, r.binaryPath, args...)
 
 	// Set environment variables.
-	if len(req.Env) > 0 {
+	if len(effective.Env) > 0 {
 		cmd.Env = os.Environ()
-		for k, v := range req.Env {
+		for k, v := range effective.Env {
 			cmd.Env = append(cmd.Env, k+"="+v)
 		}
 	}
 
 	// Pipe stdin.
-	if len(req.Stdin) > 0 {
-		cmd.Stdin = bytes.NewReader(req.Stdin)
+	if len(effective.Stdin) > 0 {
+		cmd.Stdin = bytes.NewReader(effective.Stdin)
 	}
 
-	var stdout, stderr bytes.Buffer
+	outputBudget := newOutputBudget(effective.MaxOutputBytes)
+	stdout := newCappedBuffer(outputBudget)
+	stderr := newCappedBuffer(outputBudget)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
@@ -119,9 +134,10 @@ func (r *CLIRuntime) Execute(ctx context.Context, req *ExecRequest) (*ExecResult
 	duration := time.Since(start)
 
 	result := &ExecResult{
-		Stdout:   stdout.Bytes(),
-		Stderr:   stderr.Bytes(),
-		Duration: duration,
+		Stdout:          stdout.Bytes(),
+		Stderr:          stderr.Bytes(),
+		Duration:        duration,
+		OutputTruncated: stdout.Truncated() || stderr.Truncated(),
 	}
 
 	if err != nil {
@@ -171,15 +187,18 @@ func (r *CLIRuntime) buildArgs(req *ExecRequest, memMax uint64) []string {
 func (r *CLIRuntime) buildWasmtimeArgs(req *ExecRequest, memMax uint64) []string {
 	args := []string{"run"}
 
-	// Fuel limit for bounded execution.
-	args = append(args, "--fuel", fmt.Sprintf("%d", DefaultFuel), "--max-wasm-stack", "1048576")
-
-	// Memory limit.
-	memMB := memMax / (1024 * 1024)
-	if memMB == 0 {
-		memMB = 64
+	// Wasmtime's current CLI groups semantic limits under -W/--wasm.
+	fuel := req.Fuel
+	if fuel == 0 {
+		fuel = DefaultFuel
 	}
-	args = append(args, fmt.Sprintf("-O max-memory=%d", memMB*1024*1024))
+	args = append(args, "-W", fmt.Sprintf("fuel=%d,max-memory-size=%d,max-wasm-stack=1048576", fuel, memMax))
+
+	// WASI has no host filesystem access unless directories are explicitly
+	// pre-opened. Each allowed path is passed before the module path.
+	for _, allowed := range req.AllowedPaths {
+		args = append(args, "--dir", filepath.Clean(allowed))
+	}
 
 	// Function to invoke (if not _start).
 	if req.Function != "" && req.Function != "_start" {
@@ -238,6 +257,58 @@ func (r *CLIRuntime) buildWasmerArgs(req *ExecRequest, memMax uint64) []string {
 	}
 
 	return args
+}
+
+// validateLimits fails closed for CLI runtimes that cannot enforce the
+// configured instruction, memory, or filesystem limits consistently.
+func (r *CLIRuntime) validateLimits(req *ExecRequest) error {
+	if r.runtimeName == "wasmtime" {
+		return nil
+	}
+	if req.Fuel > 0 || req.MemoryMax > 0 || len(req.AllowedPaths) > 0 {
+		return fmt.Errorf("%w: %s", ErrUnsupportedLimits, r.runtimeName)
+	}
+	return nil
+}
+
+type cappedBuffer struct {
+	buf    bytes.Buffer
+	budget *outputBudget
+}
+
+type outputBudget struct {
+	mu        sync.Mutex
+	remaining int64
+	truncated bool
+}
+
+func newOutputBudget(max int64) *outputBudget { return &outputBudget{remaining: max} }
+
+func newCappedBuffer(budget *outputBudget) cappedBuffer { return cappedBuffer{budget: budget} }
+
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	originalLen := len(p)
+	b.budget.mu.Lock()
+	defer b.budget.mu.Unlock()
+	if b.budget.remaining <= 0 {
+		b.budget.truncated = b.budget.truncated || originalLen > 0
+		return originalLen, nil
+	}
+	if int64(len(p)) > b.budget.remaining {
+		p = p[:b.budget.remaining]
+		b.budget.truncated = true
+	}
+	_, _ = b.buf.Write(p)
+	b.budget.remaining -= int64(len(p))
+	return originalLen, nil
+}
+
+func (b *cappedBuffer) Bytes() []byte { return b.buf.Bytes() }
+func (b *cappedBuffer) String() string { return b.buf.String() }
+func (b *cappedBuffer) Truncated() bool {
+	b.budget.mu.Lock()
+	defer b.budget.mu.Unlock()
+	return b.budget.truncated
 }
 
 // runtimeNameFromPath extracts the runtime name from a binary path.

--- a/pkg/agentscope/wasm/cli_runtime.go
+++ b/pkg/agentscope/wasm/cli_runtime.go
@@ -304,7 +304,9 @@ func (b *cappedBuffer) Write(p []byte) (int, error) {
 }
 
 func (b *cappedBuffer) Bytes() []byte { return b.buf.Bytes() }
+
 func (b *cappedBuffer) String() string { return b.buf.String() }
+
 func (b *cappedBuffer) Truncated() bool {
 	b.budget.mu.Lock()
 	defer b.budget.mu.Unlock()

--- a/pkg/agentscope/wasm/sandbox.go
+++ b/pkg/agentscope/wasm/sandbox.go
@@ -14,7 +14,7 @@ type SandboxConfig struct {
 	MaxMemory      uint64        // default: 64MB
 	MaxDuration    time.Duration // default: 30s
 	MaxFuel        int64         // instruction count limit (wasmtime-specific)
-	MaxOutputBytes int64       // combined stdout/stderr capture limit (default: 1MB)
+	MaxOutputBytes int64         // combined stdout/stderr capture limit (default: 1MB)
 }
 
 // Sandbox provides a safe execution environment for WASM modules.

--- a/pkg/agentscope/wasm/sandbox.go
+++ b/pkg/agentscope/wasm/sandbox.go
@@ -9,11 +9,12 @@ import (
 
 // SandboxConfig configures the WASM sandbox.
 type SandboxConfig struct {
-	Runtime      Runtime
-	AllowedPaths []string      // paths the module can access (if WASI enabled)
-	MaxMemory    uint64        // default: 64MB
-	MaxDuration  time.Duration // default: 30s
-	MaxFuel      int64         // instruction count limit (wasmtime-specific)
+	Runtime        Runtime
+	AllowedPaths   []string      // paths the module can access (if WASI enabled)
+	MaxMemory      uint64        // default: 64MB
+	MaxDuration    time.Duration // default: 30s
+	MaxFuel        int64         // instruction count limit (wasmtime-specific)
+	MaxOutputBytes int64       // combined stdout/stderr capture limit (default: 1MB)
 }
 
 // Sandbox provides a safe execution environment for WASM modules.
@@ -31,6 +32,9 @@ func NewSandbox(cfg SandboxConfig) *Sandbox {
 	}
 	if cfg.MaxFuel == 0 {
 		cfg.MaxFuel = DefaultFuel
+	}
+	if cfg.MaxOutputBytes == 0 {
+		cfg.MaxOutputBytes = DefaultOutputMax
 	}
 	return &Sandbox{cfg: cfg}
 }
@@ -52,12 +56,15 @@ func (s *Sandbox) RunWithArgs(ctx context.Context, modulePath string, args []str
 	}
 
 	req := &ExecRequest{
-		ModulePath: modulePath,
-		Function:   "_start",
-		Stdin:      input,
-		Args:       args,
-		Timeout:    s.cfg.MaxDuration,
-		MemoryMax:  s.cfg.MaxMemory,
+		ModulePath:     modulePath,
+		Function:       "_start",
+		Stdin:          input,
+		Args:           args,
+		AllowedPaths:   append([]string(nil), s.cfg.AllowedPaths...),
+		Timeout:        s.cfg.MaxDuration,
+		MemoryMax:      s.cfg.MaxMemory,
+		Fuel:           s.cfg.MaxFuel,
+		MaxOutputBytes: s.cfg.MaxOutputBytes,
 	}
 
 	return s.cfg.Runtime.Execute(ctx, req)

--- a/pkg/agentscope/wasm/wasm.go
+++ b/pkg/agentscope/wasm/wasm.go
@@ -16,21 +16,25 @@ type Runtime interface {
 
 // ExecRequest describes what to execute.
 type ExecRequest struct {
-	ModulePath string            // path to .wasm file
-	Function   string            // exported function name (default: "_start")
-	Stdin      []byte            // data piped to stdin
-	Env        map[string]string // environment variables
-	Args       []string          // command-line arguments
-	Timeout    time.Duration     // execution timeout (default: 30s)
-	MemoryMax  uint64            // max memory in bytes (default: 64MB)
+	ModulePath     string            // path to .wasm file
+	Function       string            // exported function name (default: "_start")
+	Stdin          []byte            // data piped to stdin
+	Env            map[string]string // environment variables
+	Args           []string          // command-line arguments
+	AllowedPaths   []string          // host paths exposed to WASI; empty exposes none
+	Timeout        time.Duration     // execution timeout (default: 30s)
+	MemoryMax      uint64            // max memory in bytes (default: 64MB)
+	Fuel           int64             // instruction fuel limit
+	MaxOutputBytes int64            // combined stdout/stderr capture bound
 }
 
 // ExecResult holds the output of a WASM execution.
 type ExecResult struct {
-	Stdout   []byte
-	Stderr   []byte
-	ExitCode int
-	Duration time.Duration
+	Stdout          []byte
+	Stderr          []byte
+	ExitCode        int
+	Duration        time.Duration
+	OutputTruncated bool
 }
 
 // Default values.
@@ -38,12 +42,14 @@ const (
 	DefaultTimeout   = 30 * time.Second
 	DefaultMemoryMax = 64 * 1024 * 1024 // 64MB
 	DefaultFuel      = int64(1_000_000)
+	DefaultOutputMax = int64(1024 * 1024)
 )
 
 // Errors.
 var (
-	ErrTimeout         = errors.New("wasm: execution timed out")
-	ErrMemoryExceeded  = errors.New("wasm: memory limit exceeded")
-	ErrModuleNotFound  = errors.New("wasm: module not found")
-	ErrRuntimeNotFound = errors.New("wasm: runtime binary not found")
+	ErrTimeout           = errors.New("wasm: execution timed out")
+	ErrMemoryExceeded    = errors.New("wasm: memory limit exceeded")
+	ErrModuleNotFound    = errors.New("wasm: module not found")
+	ErrRuntimeNotFound   = errors.New("wasm: runtime binary not found")
+	ErrUnsupportedLimits = errors.New("wasm: runtime cannot enforce requested limits")
 )

--- a/pkg/agentscope/wasm/wasm.go
+++ b/pkg/agentscope/wasm/wasm.go
@@ -25,7 +25,7 @@ type ExecRequest struct {
 	Timeout        time.Duration     // execution timeout (default: 30s)
 	MemoryMax      uint64            // max memory in bytes (default: 64MB)
 	Fuel           int64             // instruction fuel limit
-	MaxOutputBytes int64            // combined stdout/stderr capture bound
+	MaxOutputBytes int64             // combined stdout/stderr capture bound
 }
 
 // ExecResult holds the output of a WASM execution.

--- a/pkg/agentscope/wasm/wasm_test.go
+++ b/pkg/agentscope/wasm/wasm_test.go
@@ -2,6 +2,7 @@ package wasm
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,6 +40,10 @@ func TestCLIRuntime_CommandConstruction_Wasmtime(t *testing.T) {
 		Function:   "process",
 		Args:       []string{"--input", "data.json"},
 		Env:        map[string]string{"KEY": "value"},
+		Fuel:       42,
+		AllowedPaths: []string{
+			"/tmp/input",
+		},
 	}
 
 	args := rt.BuildArgs(req, 64*1024*1024)
@@ -51,17 +56,17 @@ func TestCLIRuntime_CommandConstruction_Wasmtime(t *testing.T) {
 	joined := strings.Join(args, " ")
 
 	// Should contain fuel flag.
-	if !strings.Contains(joined, "--fuel") {
-		t.Error("expected --fuel flag in wasmtime args")
+	if !strings.Contains(joined, "fuel=42") {
+		t.Error("expected fuel limit in wasmtime args")
 	}
 
-	// Should contain max-wasm-stack.
-	if !strings.Contains(joined, "--max-wasm-stack") {
-		t.Error("expected --max-wasm-stack flag in wasmtime args")
+	// Should contain max-wasm-stack in the grouped -W options.
+	if !strings.Contains(joined, "max-wasm-stack=1048576") {
+		t.Error("expected max-wasm-stack option in wasmtime args")
 	}
 
 	// Should contain memory limit.
-	if !strings.Contains(joined, "max-memory=") {
+	if !strings.Contains(joined, "max-memory-size=") {
 		t.Error("expected max-memory option in wasmtime args")
 	}
 
@@ -73,6 +78,9 @@ func TestCLIRuntime_CommandConstruction_Wasmtime(t *testing.T) {
 	// Should contain the module path.
 	if !strings.Contains(joined, "/tmp/module.wasm") {
 		t.Error("expected module path in args")
+	}
+	if !strings.Contains(joined, "--dir /tmp/input") {
+		t.Errorf("expected configured allowed path in args, got: %s", joined)
 	}
 
 	// Should contain env.
@@ -101,6 +109,41 @@ func TestCLIRuntime_CommandConstruction_Wasmtime(t *testing.T) {
 	// Module args should come after --.
 	if separatorIdx+1 >= len(args) || args[separatorIdx+1] != "--input" {
 		t.Error("expected module args after --")
+	}
+}
+
+func TestSandboxPassesAllLimitsToRuntime(t *testing.T) {
+	module := filepath.Join(t.TempDir(), "module.wasm")
+	if err := os.WriteFile(module, []byte("wasm"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rt := &mockRuntime{result: &ExecResult{}}
+	s := NewSandbox(SandboxConfig{
+		Runtime:        rt,
+		AllowedPaths:   []string{"/safe/input"},
+		MaxMemory:      32 * 1024 * 1024,
+		MaxDuration:    2 * time.Second,
+		MaxFuel:        1234,
+		MaxOutputBytes: 4096,
+	})
+	if _, err := s.Run(context.Background(), module, nil); err != nil {
+		t.Fatal(err)
+	}
+	if rt.lastReq.Fuel != 1234 || rt.lastReq.MaxOutputBytes != 4096 {
+		t.Fatalf("request limits not propagated: %#v", rt.lastReq)
+	}
+	if len(rt.lastReq.AllowedPaths) != 1 || rt.lastReq.AllowedPaths[0] != "/safe/input" {
+		t.Fatalf("allowed paths not propagated: %#v", rt.lastReq.AllowedPaths)
+	}
+}
+
+func TestCLIRuntimeRejectsUnsupportedStrictLimits(t *testing.T) {
+	for _, runtimeName := range []string{"wasm3", "wasmer"} {
+		rt := &CLIRuntime{runtimeName: runtimeName}
+		err := rt.validateLimits(&ExecRequest{Fuel: 1, MemoryMax: 1024})
+		if !errors.Is(err, ErrUnsupportedLimits) {
+			t.Errorf("%s: expected ErrUnsupportedLimits, got %v", runtimeName, err)
+		}
 	}
 }
 

--- a/pkg/agentscope/wasm/wasm_test.go
+++ b/pkg/agentscope/wasm/wasm_test.go
@@ -79,7 +79,7 @@ func TestCLIRuntime_CommandConstruction_Wasmtime(t *testing.T) {
 	if !strings.Contains(joined, "/tmp/module.wasm") {
 		t.Error("expected module path in args")
 	}
-	if !strings.Contains(joined, "--dir /tmp/input") {
+	if !strings.Contains(joined, "--dir "+filepath.Clean("/tmp/input")) {
 		t.Errorf("expected configured allowed path in args, got: %s", joined)
 	}
 


### PR DESCRIPTION
## Why

The loop bridge could bypass confirmation semantics, session turns could lose configured history, and TCP response cleanup could remove a replacement request. WASM limits were incompletely propagated and the Windows assertion used a Unix-only path.

## Changes

- Implement the actual loop.ToolExecutor interface through tool.Orchestrator; resolve one tool instance for permission checking and execution.
- Reject case-insensitive tool-name collisions, stabilize schema ordering, and report synchronous Bash failures as tool errors.
- Apply acting middleware rewrites and fail closed for confirmation-required or external execution in the loop bridge.
- Propagate WASM fuel, memory, directory grants and bounded output capture; unsupported CLI limits fail closed.
- Make TCP shutdown and transport cancellation responsive; atomically claim unary responses and protect replacement entries during cleanup.
- Preserve the configured ContextManager across serialized session turns, drain the loop on budget cancellation, and persist message history with atomic file saves.
- Add regression tests, correct Windows path expectations and formatting, and let every OS CI job finish independently.

## Validation

- Independent adversarial evaluator: static PASS, no HIGH findings, for the final patch.
- git diff --check: passed.
- GitHub Actions CI passed on 95b523aedeb1718f0819acf3ca0e6b13c469d12c: Linux/macOS/Windows build, vet and race tests; lint; four cross-architecture builds; Linux coverage, fuzz smoke and benchmark. Run: https://github.com/AlanFokCo/agentscope-go/actions/runs/33936107781
- The user authorized PR-branch CI validation because the workspace has no Go toolchain and the configured builder is unavailable.
- The user authorized merge after evaluator and CI pass; the merge request is pinned to the validated head SHA.

## Scope

See docs/adversarial-hardening.md for behavior and remaining limitations. TCP is NDJSON, not the gRPC wire protocol; canceled requests should use fresh IDs on retry, established streams still require draining or client close, and session snapshots share message objects. This batch does not resolve every repository-wide audit finding.