### PR TITLE
fix: isolate TCP stream cancellation and backpressure

### DIFF
--- a/docs/adversarial-hardening.md
+++ b/docs/adversarial-hardening.md
@@ -18,6 +18,14 @@ This batch tightens the execution, WASM, TCP, and experimental runtime paths.
 - `a2a/grpc` uses newline-delimited JSON over TCP. It is not the gRPC wire
   protocol. Transport I/O observes context cancellation, and client/server close
   releases idle connections. Active request and stream IDs share one namespace.
+  Stream cancellation retires the local registration and closes its channel.
+  A full 64-message stream buffer closes that stream without blocking other
+  requests on the connection. Buffered messages remain readable after closure;
+  consumers must receive `StreamEnd` to treat the stream as successfully complete.
+  Closure without `StreamEnd` means interruption (cancellation, disconnect, or
+  overflow). Cancellation does not send a remote cancellation frame.
+  Send cancellation also applies while waiting for another writer. Failed
+  writes close the connection because a partial JSON frame cannot be reused.
   Use a fresh ID when retrying a canceled request: late responses cannot be
   distinguished from a new request using the same ID on this wire protocol.
 - `runtime.SessionEngine` serializes turns and preserves the context manager
@@ -31,8 +39,9 @@ This batch tightens the execution, WASM, TCP, and experimental runtime paths.
 
 This batch does not establish a complete isolation boundary for arbitrary
 custom tools. Configure a workspace backend for isolated shell/file execution.
-The TCP stream consumer must continue draining its channel or close its client;
-stream-context cancellation alone does not retire an established stream.
+TCP consumers must handle stream interruption and choose an application-level
+retry policy using fresh request IDs. A closed stream channel does not by itself
+mean that the remote work succeeded or stopped.
 Session-state snapshots copy the message slice but share message objects, and
 session-store saves do not provide an automatic restore/resume constructor.
 

--- a/pkg/agentscope/a2a/grpc/client_stream.go
+++ b/pkg/agentscope/a2a/grpc/client_stream.go
@@ -1,0 +1,49 @@
+package grpc
+
+import "sync"
+
+// clientStream owns channel delivery and closure. Sending never blocks while
+// holding mu; cancellation can safely close the channel at any time.
+type clientStream struct {
+	mu       sync.Mutex
+	messages chan *Message
+	closed   bool
+	stop     func() bool
+}
+
+// deliver reports whether the stream remains active. Overflow closes the
+// stream without a synthetic StreamEnd, preserving an observable distinction
+// between successful completion and interruption.
+func (s *clientStream) deliver(msg *Message) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return false
+	}
+	select {
+	case s.messages <- msg:
+		if !msg.StreamEnd {
+			return true
+		}
+	default:
+	}
+	s.closeLocked()
+	return false
+}
+
+func (s *clientStream) close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closeLocked()
+}
+
+func (s *clientStream) closeLocked() {
+	if s.closed {
+		return
+	}
+	s.closed = true
+	if s.stop != nil {
+		s.stop()
+	}
+	close(s.messages)
+}

--- a/pkg/agentscope/a2a/grpc/lifecycle_test.go
+++ b/pkg/agentscope/a2a/grpc/lifecycle_test.go
@@ -1,0 +1,304 @@
+package grpc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newPipeClient(t *testing.T) (*Client, *connTransport) {
+	t.Helper()
+	peer, conn := net.Pipe()
+	c := &Client{
+		conn:    conn,
+		t:       newConnTransport(conn),
+		pending: make(map[string]chan *Message),
+		streams: make(map[string]*clientStream),
+		closed:  make(chan struct{}),
+	}
+	c.readWg.Add(1)
+	go c.readLoop()
+	t.Cleanup(func() {
+		_ = peer.Close()
+		_ = c.Close()
+	})
+	return c, newConnTransport(peer)
+}
+
+func TestStreamCancellationReleasesIdleStream(t *testing.T) {
+	c, peer := newPipeClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	serverDone := make(chan error, 1)
+	go func() {
+		if _, err := peer.Receive(ctx); err != nil {
+			serverDone <- err
+			return
+		}
+		req, err := peer.Receive(ctx)
+		if err == nil {
+			err = peer.Send(ctx, &Message{ID: req.ID, Method: "ack"})
+		}
+		serverDone <- err
+	}()
+	streamCtx, stop := context.WithCancel(ctx)
+	defer stop()
+	ch, err := c.Stream(streamCtx, &Message{ID: "idle"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop()
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("idle stream unexpectedly produced a message")
+		}
+	case <-ctx.Done():
+		t.Fatal("cancel did not close the idle stream")
+	}
+	c.mu.Lock()
+	registered := c.streams["idle"] != nil
+	c.mu.Unlock()
+	if registered {
+		t.Fatal("canceled stream remains registered")
+	}
+	if _, err := c.Send(ctx, &Message{ID: "ordinary"}); err != nil {
+		t.Fatalf("stream cancellation broke the connection: %v", err)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSlowStreamDoesNotBlockOtherRequests(t *testing.T) {
+	c, peer := newPipeClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	produced := make(chan error, 1)
+	serverDone := make(chan error, 1)
+	go func() {
+		if _, err := peer.Receive(ctx); err != nil {
+			produced <- err
+			return
+		}
+		for i := 0; i < 80; i++ {
+			if err := peer.Send(ctx, &Message{ID: "slow", Method: "chunk"}); err != nil {
+				produced <- err
+				return
+			}
+		}
+		produced <- nil
+		req, err := peer.Receive(ctx)
+		if err == nil {
+			err = peer.Send(ctx, &Message{ID: req.ID, Method: "ack"})
+		}
+		serverDone <- err
+	}()
+	ch, err := c.Stream(ctx, &Message{ID: "slow"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := <-produced; err != nil {
+		t.Fatalf("slow stream blocked the shared reader: %v", err)
+	}
+	if _, err := c.Send(ctx, &Message{ID: "ordinary"}); err != nil {
+		t.Fatalf("ordinary request blocked behind a slow stream: %v", err)
+	}
+	count := 0
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				if count != 64 {
+					t.Fatalf("received %d buffered messages, want 64", count)
+				}
+				if err := <-serverDone; err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			count++
+			if msg.StreamEnd {
+				t.Fatal("overflow must not masquerade as successful stream completion")
+			}
+		case <-ctx.Done():
+			t.Fatal("overflowed stream did not close")
+		}
+	}
+}
+
+func TestPeerClosePreservesQueuedStreamEnd(t *testing.T) {
+	c, peer := newPipeClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go func() {
+		if _, err := peer.Receive(ctx); err != nil {
+			return
+		}
+		_ = peer.Send(ctx, &Message{ID: "complete", StreamEnd: true})
+		_ = peer.Close()
+	}()
+	ch, err := c.Stream(ctx, &Message{ID: "complete"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case msg := <-ch:
+		if msg == nil || !msg.StreamEnd {
+			t.Fatal("peer close lost the already-received final message")
+		}
+	case <-ctx.Done():
+		t.Fatal("stream did not finish")
+	}
+}
+
+func TestStreamCancellationRacesWithDeliveryAndClientClose(t *testing.T) {
+	for i := 0; i < 25; i++ {
+		c, peer := newPipeClient(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		streamCtx, stop := context.WithCancel(ctx)
+		ready := make(chan struct{})
+		serverDone := make(chan struct{})
+		go func() {
+			defer close(serverDone)
+			if _, err := peer.Receive(ctx); err != nil {
+				return
+			}
+			<-ready
+			_ = peer.Send(ctx, &Message{ID: "race", StreamEnd: true})
+		}()
+		ch, err := c.Stream(streamCtx, &Message{ID: "race"})
+		if err != nil {
+			stop()
+			cancel()
+			close(ready)
+			t.Fatal(err)
+		}
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-ready
+			stop()
+		}()
+		go func() {
+			defer wg.Done()
+			<-ready
+			_ = c.Close()
+		}()
+		close(ready)
+		wg.Wait()
+		for range ch {
+		}
+		c.mu.Lock()
+		remaining := len(c.streams)
+		c.mu.Unlock()
+		if remaining != 0 {
+			t.Errorf("iteration %d retained %d stream registrations", i, remaining)
+		}
+		<-serverDone
+		cancel()
+	}
+}
+
+type writeSignalConn struct {
+	net.Conn
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (c *writeSignalConn) Write(p []byte) (int, error) {
+	c.once.Do(func() { close(c.entered) })
+	return c.Conn.Write(p)
+}
+
+func TestSendCancellationWhileWaitingForWriter(t *testing.T) {
+	peer, conn := net.Pipe()
+	defer func() { _ = peer.Close() }()
+	defer func() { _ = conn.Close() }()
+	signaled := &writeSignalConn{Conn: conn, entered: make(chan struct{})}
+	transport := newConnTransport(signaled)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- transport.Send(ctx, &Message{ID: "first"}) }()
+	select {
+	case <-signaled.entered:
+	case <-ctx.Done():
+		t.Fatal("first write did not start")
+	}
+	waitCtx, stop := context.WithTimeout(ctx, 20*time.Millisecond)
+	defer stop()
+	if err := transport.Send(waitCtx, &Message{ID: "canceled"}); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("waiting sender error = %v", err)
+	}
+	if _, err := newConnTransport(peer).Receive(ctx); err != nil {
+		t.Fatalf("waiting sender cancellation broke the active write: %v", err)
+	}
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSerializationErrorKeepsConnectionUsable(t *testing.T) {
+	c, peer := newPipeClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	serverDone := make(chan error, 1)
+	go func() {
+		req, err := peer.Receive(ctx)
+		if err == nil {
+			err = peer.Send(ctx, &Message{ID: req.ID, Method: "ack"})
+		}
+		serverDone <- err
+	}()
+	if _, err := c.Send(ctx, &Message{ID: "invalid", Payload: json.RawMessage("{")}); err == nil {
+		t.Fatal("invalid JSON message was accepted")
+	}
+	if _, err := c.Send(ctx, &Message{ID: "valid"}); err != nil {
+		t.Fatalf("local serialization error damaged the connection: %v", err)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+type partialFailureConn struct{ net.Conn }
+
+func (c *partialFailureConn) Write(p []byte) (int, error) {
+	n, err := c.Conn.Write(p[:1])
+	if err != nil {
+		return n, err
+	}
+	return n, io.ErrUnexpectedEOF
+}
+
+func TestFailedPartialWriteClosesConnection(t *testing.T) {
+	peer, conn := net.Pipe()
+	defer func() { _ = peer.Close() }()
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	readDone := make(chan int, 1)
+	go func() {
+		data, _ := io.ReadAll(peer)
+		readDone <- len(data)
+	}()
+	err := newConnTransport(&partialFailureConn{Conn: conn}).Send(ctx, &Message{ID: "partial"})
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("Send error = %v", err)
+	}
+	select {
+	case n := <-readDone:
+		if n != 1 {
+			t.Fatalf("peer received %d bytes, want one partial byte", n)
+		}
+	case <-ctx.Done():
+		t.Fatal("partial write left the damaged connection open")
+	}
+}

--- a/pkg/agentscope/a2a/grpc/transport.go
+++ b/pkg/agentscope/a2a/grpc/transport.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"sync"
 	"time"
@@ -32,28 +33,48 @@ type Transport interface {
 
 // connTransport implements Transport over a single TCP connection using newline-delimited JSON.
 type connTransport struct {
-	conn    net.Conn
-	encoder *json.Encoder
-	scanner *bufio.Scanner
-	mu      sync.Mutex // protects encoder writes
+	conn      net.Conn
+	scanner   *bufio.Scanner
+	writeGate chan struct{} // serializes frame writes, with cancelable admission
 }
 
 func newConnTransport(conn net.Conn) *connTransport {
 	scanner := bufio.NewScanner(conn)
 	scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // 1MB max message
 	return &connTransport{
-		conn:    conn,
-		encoder: json.NewEncoder(conn),
-		scanner: scanner,
+		conn:      conn,
+		scanner:   scanner,
+		writeGate: make(chan struct{}, 1),
 	}
 }
 
 func (t *connTransport) Send(ctx context.Context, msg *Message) error {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+	select {
+	case t.writeGate <- struct{}{}:
+		defer func() { <-t.writeGate }()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	// Serialize before touching the connection. Invalid local message data
+	// must not interrupt unrelated requests using the same transport.
+	frame, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("transport: marshal: %w", err)
+	}
+	frame = append(frame, '\n')
 	restore := armContextDeadline(ctx, t.conn.SetWriteDeadline)
 	defer restore()
-	if err := t.encoder.Encode(msg); err != nil {
+	n, err := t.conn.Write(frame)
+	if err == nil && n != len(frame) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		// A failed write may leave a partial JSON frame on the wire. Further
+		// requests cannot safely reuse that connection.
+		_ = t.conn.Close()
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
 		}
@@ -260,7 +281,7 @@ type Client struct {
 	t          *connTransport
 	mu         sync.Mutex
 	pending    map[string]chan *Message
-	streams    map[string]chan *Message
+	streams    map[string]*clientStream
 	closed     chan struct{}
 	readClosed bool
 	closeOnce  sync.Once
@@ -279,7 +300,7 @@ func NewClient(addr string) (*Client, error) {
 		conn:    conn,
 		t:       newConnTransport(conn),
 		pending: make(map[string]chan *Message),
-		streams: make(map[string]chan *Message),
+		streams: make(map[string]*clientStream),
 		closed:  make(chan struct{}),
 	}
 	c.readWg.Add(1)
@@ -297,31 +318,26 @@ func (c *Client) readLoop() {
 		}
 
 		c.mu.Lock()
-		streamCh, isStream := c.streams[msg.ID]
+		stream, isStream := c.streams[msg.ID]
+		if isStream {
+			// Delivery never blocks. Keep removal and channel closure under
+			// the registry lock so observing a closed channel also permits
+			// a subsequent registration without a stale duplicate entry.
+			if !stream.deliver(msg) {
+				delete(c.streams, msg.ID)
+			}
+			c.mu.Unlock()
+			continue
+		}
 		pendingCh, isPending := c.pending[msg.ID]
 		// Claim this response while holding the registry lock. A canceled
 		// request may be replaced as soon as the lock is released.
-		if isPending && !isStream {
+		if isPending {
 			delete(c.pending, msg.ID)
 		}
 		c.mu.Unlock()
 
-		// Never hold c.mu while sending to a consumer-controlled channel.
-		if isStream {
-			select {
-			case streamCh <- msg:
-			case <-c.closed:
-				return
-			}
-			if msg.StreamEnd {
-				c.mu.Lock()
-				if c.streams[msg.ID] == streamCh {
-					delete(c.streams, msg.ID)
-				}
-				c.mu.Unlock()
-				close(streamCh)
-			}
-		} else if isPending {
+		if isPending {
 			pendingCh <- msg
 			close(pendingCh)
 		}
@@ -336,10 +352,18 @@ func (c *Client) closeResponseChannels() {
 		close(ch)
 		delete(c.pending, id)
 	}
-	for id, ch := range c.streams {
-		close(ch)
+	for id, stream := range c.streams {
+		stream.close()
 		delete(c.streams, id)
 	}
+}
+
+func (c *Client) removeStream(id string, stream *clientStream) {
+	c.mu.Lock()
+	if c.streams[id] == stream {
+		delete(c.streams, id)
+	}
+	c.mu.Unlock()
 }
 
 // Send sends a request and waits for a single response (request-response pattern).
@@ -387,12 +411,19 @@ func (c *Client) Send(ctx context.Context, msg *Message) (*Message, error) {
 }
 
 // Stream sends a message and returns a channel that receives streaming responses.
-// The channel is closed after a message with StreamEnd=true is received.
+// The channel closes on StreamEnd, context cancellation, connection loss, or
+// overflow of its 64-message buffer. Buffered messages remain readable after
+// closure. Completion is successful only if the consumer receives StreamEnd;
+// closure without it indicates interruption. Cancellation retires the local
+// stream; this protocol has no remote cancellation frame.
 func (c *Client) Stream(ctx context.Context, msg *Message) (<-chan *Message, error) {
 	if msg == nil {
 		return nil, errors.New("client: nil message")
 	}
-	ch := make(chan *Message, 64)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	stream := &clientStream{messages: make(chan *Message, 64)}
 
 	c.mu.Lock()
 	if c.readClosed {
@@ -403,21 +434,25 @@ func (c *Client) Stream(ctx context.Context, msg *Message) (<-chan *Message, err
 		c.mu.Unlock()
 		return nil, fmt.Errorf("client: duplicate stream ID %q", msg.ID)
 	}
-	c.streams[msg.ID] = ch
+	c.streams[msg.ID] = stream
+	id := msg.ID
+	// Install cancellation while holding the registry lock. The callback and
+	// reader cannot reach the stream before its stop function is initialized.
+	stream.stop = context.AfterFunc(ctx, func() {
+		c.removeStream(id, stream)
+		stream.close()
+	})
 	c.mu.Unlock()
 
 	request := *msg
 	request.IsStream = true
 	if err := c.t.Send(ctx, &request); err != nil {
-		c.mu.Lock()
-		if c.streams[msg.ID] == ch {
-			delete(c.streams, msg.ID)
-		}
-		c.mu.Unlock()
+		c.removeStream(id, stream)
+		stream.close()
 		return nil, fmt.Errorf("client: stream send: %w", err)
 	}
 
-	return ch, nil
+	return stream.messages, nil
 }
 
 // Close terminates the client connection.

--- a/pkg/agentscope/a2a/grpc/transport_test.go
+++ b/pkg/agentscope/a2a/grpc/transport_test.go
@@ -283,7 +283,7 @@ func TestResponseClaimDoesNotDeleteReplacement(t *testing.T) {
 		conn:    clientConn,
 		t:       newConnTransport(clientConn),
 		pending: map[string]chan *Message{"retry": old},
-		streams: make(map[string]chan *Message),
+		streams: make(map[string]*clientStream),
 		closed:  make(chan struct{}),
 	}
 	c.readWg.Add(1)
@@ -334,7 +334,7 @@ func TestResponseClaimDoesNotDeleteReplacement(t *testing.T) {
 func TestClientRejectsCrossModeDuplicateIDs(t *testing.T) {
 	c := &Client{
 		pending: make(map[string]chan *Message),
-		streams: map[string]chan *Message{"shared": make(chan *Message, 1)},
+		streams: map[string]*clientStream{"shared": {messages: make(chan *Message, 1)}},
 	}
 	if _, err := c.Send(context.Background(), &Message{ID: "shared"}); err == nil {
 		t.Fatal("Send accepted an active stream ID")


### PR DESCRIPTION
## Why

Canceling an established TCP stream left its channel and registration alive. A slow stream consumer could block the shared reader and stall unrelated request/response traffic. Writers also ignored cancellation while waiting for the encoder lock, and a failed partial write could leave the connection's JSON framing unusable.

## Changes

- Give each stream synchronized channel ownership and a context cancellation callback. Close/removal cannot race with delivery.
- Keep the 64-message buffer bounded; overflow interrupts only that stream and does not block unrelated requests. Preserve already queued messages, including an accepted final response on peer close.
- Document that successful completion requires receiving StreamEnd. A channel closing without it signals interruption; local cancellation does not send a remote cancel frame.
- Make writer admission context-aware. Serialize JSON before network I/O, keep connections usable after local serialization failures, and close on failed or short network writes.
- Add seven pipe-based regression tests, including repeated cancellation/final-response/client-close races.

## Validation

- Independent adversarial evaluator: static PASS, no HIGH or MEDIUM findings in the final patch.
- git diff --check: passed.
- GitHub Actions passed for 5a842df83e119ae4854cbe9b5895ac8597087b45: Linux/macOS/Windows build, vet and race tests; lint; arm/arm64/mips64le/riscv64 cross-builds; Linux coverage, fuzz smoke and benchmark. Run: https://github.com/AlanFokCo/agentscope-go/actions/runs/33957930061
- The user authorized CI-first PR validation and merge only after evaluator and final-commit CI pass. No local Go toolchain is available.

## Scope

This continues PR #4 and updates docs/adversarial-hardening.md. Session-state deep isolation, automatic restore, and broader custom-tool sandbox boundaries are outside this batch.